### PR TITLE
Remove nvidia x11 drivers from @hardware-support group

### DIFF
--- a/comps-devel.xml.in
+++ b/comps-devel.xml.in
@@ -59,9 +59,6 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="optional">broadcom-wl</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-304xx</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-340xx</packagereq>
     </packagelist>
   </group>
   <group>

--- a/comps-el7.xml.in
+++ b/comps-el7.xml.in
@@ -59,9 +59,6 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="optional">broadcom-wl</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-304xx</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-340xx</packagereq>
     </packagelist>
   </group>
   <group>

--- a/comps-f24.xml.in
+++ b/comps-f24.xml.in
@@ -59,9 +59,6 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="optional">broadcom-wl</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-304xx</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-340xx</packagereq>
     </packagelist>
   </group>
   <group>

--- a/comps-f25.xml.in
+++ b/comps-f25.xml.in
@@ -59,9 +59,6 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="optional">broadcom-wl</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-304xx</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-340xx</packagereq>
     </packagelist>
   </group>
   <group>

--- a/comps-f26.xml.in
+++ b/comps-f26.xml.in
@@ -59,9 +59,6 @@
     <uservisible>true</uservisible>
     <packagelist>
       <packagereq type="optional">broadcom-wl</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-304xx</packagereq>
-      <packagereq type="optional">xorg-x11-drv-nvidia-340xx</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
When the optional packages of @hardware-support are requested, a set
of xorg-x11-nvidia* drivers get pulled in. Some of them (e.g. 304xx)
drop in their own /etc/X11/*xorg.conf file, assuming the relvant
hardware is present, and, if that's not the case, breaking X11 hardware
autodetection in the process.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>